### PR TITLE
Fix components clipped from the form

### DIFF
--- a/src/components/CenteredCardLayout.jsx
+++ b/src/components/CenteredCardLayout.jsx
@@ -10,11 +10,10 @@ export default function CenteredCardLayout({ children }) {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-sky-50">
       <motion.div
-        className="bg-white shadow rounded p-8 w-full max-w-md mb-10"
+        className={`bg-white shadow rounded p-8 w-full max-w-md mb-10 ${isAnimating ? "overflow-hidden" : "overflow-visible"}`}
         initial={{ height: 0 }}
         animate={{ height: "auto" }}
         exit={{ height: 0 }}
-        style={{ overflow: isAnimating ? "hidden" : "visible" }}
         onAnimationStart={() => setIsAnimating(true)}
         onAnimationComplete={() => setIsAnimating(false)}
       >

--- a/src/components/Collapsible.jsx
+++ b/src/components/Collapsible.jsx
@@ -8,10 +8,10 @@ const Collapsible = ({ isOpened, children }) => {
     <AnimatePresence>
       {isOpened && (
         <motion.div
+          className={isAnimating ? "overflow-hidden" : "overflow-visible"}
           initial={{ height: 0, opacity: 0 }}
           animate={{ height: "auto", opacity: 1 }}
           exit={{ height: 0, opacity: 0 }}
-          style={{ overflow: isAnimating ? "hidden" : "visible" }}
           onAnimationStart={() => setIsAnimating(true)}
           onAnimationComplete={() => setIsAnimating(false)}
         >


### PR DESCRIPTION
- Only applies overflow: hidden to the card container while the framer-motion height animation is running.
- Uses React state to toggle overflow, preventing content clipping during animation but allowing dropdowns/popovers to display correctly when idle.