### PR TITLE
feat: add loading screen and euro loading spinner components, in order not to show the login page on autologin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,12 +12,7 @@ export default [
   pluginReact.configs.flat["jsx-runtime"],
   eslintImport.flatConfigs.recommended,
   {
-    ignores: [
-      "dist/**",
-      "dev-dist/**", 
-      "coverage/**",
-      "node_modules/**",
-    ],
+    ignores: ["dist/**", "dev-dist/**", "coverage/**", "node_modules/**"],
   },
   {
     files: ["**/*.{js,mjs,cjs,jsx,mjsx,ts,tsx,mtsx}"],

--- a/src/LoginPage.jsx
+++ b/src/LoginPage.jsx
@@ -34,9 +34,6 @@ export default function LoginPage() {
     }
   }, [user, ynabToken, navigate]);
 
-  // Prevent rendering if user is authenticated (prevents flicker)
-  if (user && ynabToken) return null;
-
   const handleGoogleSignIn = async () => {
     setIsLoading(true);
     setError("");

--- a/src/LoginPage.test.jsx
+++ b/src/LoginPage.test.jsx
@@ -150,12 +150,21 @@ describe("LoginPage Authentication Requirements", () => {
       expect(screen.getByText("YNAB Integration")).toBeInTheDocument();
     });
 
-    test("does not render when user is authenticated and has YNAB token", () => {
+    test("renders and navigates to home when user is authenticated and has YNAB token", async () => {
       localStorage.setItem("ynab_api_key", "test-token");
       mockAuth.user = { uid: "test-user" };
 
-      const { container } = renderWithProviders(<LoginPage />);
-      expect(container.firstChild).toBeNull();
+      renderWithProviders(<LoginPage />);
+
+      // Should render the login page initially
+      expect(
+        screen.getByRole("heading", { name: "Sign In" }),
+      ).toBeInTheDocument();
+
+      // But should navigate to home
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+      });
     });
 
     test("renders when user is authenticated but missing YNAB token", () => {

--- a/src/components/EuroLoadingSpinner.jsx
+++ b/src/components/EuroLoadingSpinner.jsx
@@ -1,0 +1,147 @@
+import PropTypes from "prop-types";
+
+export default function EuroLoadingSpinner({
+  size = "w-8 h-8",
+  className = "",
+}) {
+  return (
+    <div className={`flex items-center justify-center ${className}`}>
+      <div className={`relative ${size}`}>
+        {/* Euro symbol with animated stroke */}
+        <svg viewBox="0 0 24 24" fill="none" className="w-full h-full">
+          {/* Define the stroke animation */}
+          <defs>
+            <style>
+              {`
+                .euro-path {
+                  stroke-dasharray: 100;
+                  stroke-dashoffset: 100;
+                  animation: drawPath 2s ease-in-out infinite;
+                }
+                .euro-path-1 {
+                  animation-delay: 0s;
+                }
+                .euro-path-2 {
+                  animation-delay: 0.2s;
+                }
+                .euro-path-3 {
+                  animation-delay: 0.4s;
+                }
+                .euro-path-4 {
+                  animation-delay: 0.6s;
+                }
+                @keyframes drawPath {
+                  0% {
+                    stroke-dashoffset: 100;
+                    stroke-width: 1;
+                    stroke: rgb(14 165 233);
+                  }
+                  50% {
+                    stroke-dashoffset: 0;
+                    stroke-width: 2;
+                    stroke: rgb(2 132 199);
+                  }
+                  100% {
+                    stroke-dashoffset: -100;
+                    stroke-width: 1;
+                    stroke: rgb(14 165 233);
+                  }
+                }
+              `}
+            </style>
+          </defs>
+
+          {/* Euro symbol paths with sequential animation */}
+
+          {/* Static background "rail" paths - faint version */}
+          <g className="opacity-20" transform="scale(0.85) translate(1.8, 1.8)">
+            <path
+              d="M18 7c0-5.333-8-5.333-8 0"
+              stroke="rgb(14 165 233)"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+            <path
+              d="M10 7v10c0 5.333 8 5.333 8 0"
+              stroke="rgb(14 165 233)"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+            <path
+              d="M6 10h8"
+              stroke="rgb(14 165 233)"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+            <path
+              d="M6 14h8"
+              stroke="rgb(14 165 233)"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+          </g>
+
+          {/* Animated foreground paths */}
+          <g transform="scale(0.85) translate(1.8, 1.8)">
+            <path
+              d="M18 7c0-5.333-8-5.333-8 0"
+              className="euro-path euro-path-1"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+            <path
+              d="M10 7v10c0 5.333 8 5.333 8 0"
+              className="euro-path euro-path-2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+            <path
+              d="M6 10h8"
+              className="euro-path euro-path-3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+            <path
+              d="M6 14h8"
+              className="euro-path euro-path-4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+          </g>
+        </svg>
+
+        {/* Simple static outer ring */}
+        <div className="absolute inset-0">
+          <svg className="w-full h-full">
+            <circle
+              cx="50%"
+              cy="50%"
+              r="47%"
+              fill="none"
+              stroke="rgb(14 165 233)"
+              strokeWidth="1.5"
+              opacity="0.2"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+EuroLoadingSpinner.propTypes = {
+  size: PropTypes.string,
+  className: PropTypes.string,
+};

--- a/src/components/LoadingScreen.jsx
+++ b/src/components/LoadingScreen.jsx
@@ -1,0 +1,14 @@
+import EuroLoadingSpinner from "./EuroLoadingSpinner.jsx";
+
+export default function LoadingScreen() {
+  return (
+    <div className="fixed inset-0 bg-white flex items-center justify-center z-50">
+      <div className="text-center">
+        <EuroLoadingSpinner size="w-12 h-12" className="mb-4" />
+        <p className="text-gray-600 text-sm animate-pulse">
+          Loading your expense entry app...
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,6 +12,7 @@ import {
 
 import { AppProvider, useAppContext } from "./AppContext.jsx";
 import { AuthProvider, useAuth } from "./AuthProvider.jsx";
+import LoadingScreen from "./components/LoadingScreen.jsx";
 import {
   DEFAULT_SETTLEUP_CATEGORY,
   DEFAULT_SWILE_MILLIUNITS,
@@ -22,8 +23,13 @@ import NotFoundPage from "./NotFoundPage.jsx";
 import "./index.css";
 
 function RequireAuth({ children }) {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const { ynabToken } = useAppContext();
+
+  // Show loading while authentication is being checked
+  if (loading) {
+    return <LoadingScreen />;
+  }
 
   // Require both user authentication AND YNAB token
   if (!user || !ynabToken) {
@@ -33,7 +39,7 @@ function RequireAuth({ children }) {
 }
 
 function RouterApp() {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const { ynabToken } = useAppContext();
   const location = useLocation();
   const navigate = useNavigate();
@@ -58,17 +64,19 @@ function RouterApp() {
     showDetails: false,
   };
   const [formState, setFormState] = useState(DEFAULT_FORM_STATE);
+
   useEffect(() => {
     // If logged in with YNAB token and on /login, redirect to /
-    if (user && ynabToken && location.pathname === "/login") {
+    if (!loading && user && ynabToken && location.pathname === "/login") {
       console.log("[RouterApp] Auto-redirecting to / after login");
       navigate("/", { replace: true });
     }
-  }, [user, ynabToken, location.pathname, navigate]);
+  }, [user, ynabToken, location.pathname, navigate, loading]);
 
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/spinner" element={<LoadingScreen />} />
       <Route
         path="/"
         element={

--- a/src/routing.test.jsx
+++ b/src/routing.test.jsx
@@ -1,0 +1,167 @@
+import { render, screen } from "@testing-library/react";
+import PropTypes from "prop-types";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { describe, test, beforeEach, expect, vi } from "vitest";
+
+import { AppProvider, useAppContext } from "./AppContext.jsx";
+import { AuthProvider, useAuth } from "./AuthProvider.jsx";
+import LoginPage from "./LoginPage.jsx";
+
+// Mock YNAB API globally (needed by AppProvider)
+Object.defineProperty(window, "ynab", {
+  value: {
+    API: vi.fn().mockImplementation(() => ({
+      budgets: {
+        getBudgets: vi.fn().mockResolvedValue({
+          data: {
+            budgets: [
+              { id: "budget-1", name: "Test Budget 1" },
+              { id: "budget-2", name: "Test Budget 2" },
+            ],
+          },
+        }),
+      },
+    })),
+  },
+  writable: true,
+});
+
+// Mock AuthProvider hooks
+const mockAuth = {
+  user: null,
+  loading: false,
+};
+
+vi.mock("./AuthProvider.jsx", () => ({
+  AuthProvider: ({ children }) => children,
+  useAuth: () => mockAuth,
+}));
+
+describe("Application Routing", () => {
+  // Mock components that would be rendered on successful authentication
+  const MockMainFormPage = () => <div>Main Form Page</div>;
+  const MockLoadingScreen = () => <div>Loading...</div>;
+
+  // Mock RequireAuth component that mimics the behavior from main.jsx
+  const MockRequireAuth = ({ children }) => {
+    const { user, loading } = useAuth();
+    const { ynabToken } = useAppContext();
+
+    if (loading) {
+      return <MockLoadingScreen />;
+    }
+
+    if (!user || !ynabToken) {
+      return <Navigate to="/login" replace />;
+    }
+    return children;
+  };
+
+  MockRequireAuth.propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  const renderWithRouter = (initialRoute = "/") => {
+    window.history.pushState({}, "Test", initialRoute);
+
+    return render(
+      <BrowserRouter>
+        <AuthProvider>
+          <AppProvider>
+            <Routes>
+              <Route path="/login" element={<LoginPage />} />
+              <Route
+                path="/"
+                element={
+                  <MockRequireAuth>
+                    <MockMainFormPage />
+                  </MockRequireAuth>
+                }
+              />
+            </Routes>
+          </AppProvider>
+        </AuthProvider>
+      </BrowserRouter>,
+    );
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockAuth.user = null;
+    mockAuth.loading = false;
+  });
+
+  describe("Root Route (/)", () => {
+    test("redirects to login when user is not authenticated", () => {
+      mockAuth.user = null; // Not authenticated
+
+      renderWithRouter("/");
+
+      // Should redirect to login page, not show main form
+      expect(
+        screen.getByRole("heading", { name: "Sign In" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Main Form Page")).not.toBeInTheDocument();
+    });
+
+    test("redirects to login when user is authenticated but missing YNAB token", () => {
+      mockAuth.user = { uid: "test-user" }; // Authenticated
+      // No YNAB token in localStorage
+
+      renderWithRouter("/");
+
+      // Should redirect to login page
+      expect(
+        screen.getByRole("heading", { name: "Sign In" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Main Form Page")).not.toBeInTheDocument();
+    });
+
+    test("shows main app when user is authenticated and has YNAB token", () => {
+      mockAuth.user = { uid: "test-user" }; // Authenticated
+      localStorage.setItem("ynab_api_key", "test-token"); // Has YNAB token
+
+      renderWithRouter("/");
+
+      // Should show main form page, not login
+      expect(screen.getByText("Main Form Page")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: "Sign In" }),
+      ).not.toBeInTheDocument();
+    });
+
+    test("shows loading screen while authentication is being checked", () => {
+      mockAuth.loading = true; // Loading state
+
+      renderWithRouter("/");
+
+      // Should show loading screen, not login page or main form
+      expect(screen.getByText("Loading...")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: "Sign In" }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Main Form Page")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Login Route (/login)", () => {
+    test("shows login page when accessed directly", () => {
+      renderWithRouter("/login");
+
+      expect(
+        screen.getByRole("heading", { name: "Sign In" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Main Form Page")).not.toBeInTheDocument();
+    });
+
+    test("shows login page even when user is authenticated but missing YNAB token", () => {
+      mockAuth.user = { uid: "test-user" }; // Authenticated but no YNAB token
+
+      renderWithRouter("/login");
+
+      expect(
+        screen.getByRole("heading", { name: "Sign In" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/version.js
+++ b/src/version.js
@@ -3,10 +3,10 @@
 
 export const VERSION_INFO = {
   "tag": "1.0.0",
-  "branch": "HEAD",
-  "commit": "dcabfbd",
+  "branch": "SThor/issue37",
+  "commit": "a105810",
   "isDirty": true,
-  "buildTime": "2025-07-22T21:21:25.725Z",
+  "buildTime": "2025-07-23T09:14:07.540Z",
   "version": "1.0.0",
   "shortVersion": "1.0.0"
 };


### PR DESCRIPTION
## Description

### Problem
Users experienced a brief login page flicker (1-2 seconds) when opening the app with stored credentials, before auto-redirecting to the main form.

### Solution
- **Enhanced authentication flow**: Modified routing logic to check `loading` state from `AuthProvider` before rendering
- **Added custom loading screen**: Created Euro-themed loading spinner that displays during authentication initialization
- **Prevented premature routing**: Login page now waits for both user authentication AND YNAB token before navigation

### Result
Users now see a polished loading animation instead of login page flicker when the app loads with stored credentials. Maintains all existing authentication requirements while providing a much smoother user experience.

Fixes #37

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
