### PR TITLE
38 & 39: swile amount cap & fallback to single split

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -374,7 +374,7 @@ export default function App({ onSubmit, formState, setFormState }) {
           setSwileMilliunits={(val) =>
             setFormState((prev) => ({ ...prev, swileMilliunits: val }))
           }
-          max={formState.amountMilliunits}
+          min={formState.amountMilliunits}
         />
       </Collapsible>
 

--- a/src/ReviewPage.jsx
+++ b/src/ReviewPage.jsx
@@ -60,17 +60,21 @@ export default function ReviewPage({ formState, onBack, onSubmitted }) {
     if (formState.account.swile && formState.account.bourso) {
       const swileAccountId = getAccountIdByName(accounts, "Swile");
       const boursoAccountId = getAccountIdByName(accounts, "Boursorama");
-      
+
       if (!swileAccountId || !boursoAccountId) {
         setResult("No matching YNAB account found for Swile or Bourso.");
         return;
       }
 
-      const transferInflowMilliunits = formState.swileMilliunits - formState.amountMilliunits;
+      const transferInflowMilliunits =
+        formState.swileMilliunits - formState.amountMilliunits;
 
       // If Swile covers the full amount, create a simple transaction
       if (transferInflowMilliunits === 0) {
-        const transaction = createBaseTransaction(swileAccountId, formState.amountMilliunits);
+        const transaction = createBaseTransaction(
+          swileAccountId,
+          formState.amountMilliunits,
+        );
         await executeYnabTransaction(transaction, "✅ YNAB transaction sent!");
         return;
       }
@@ -94,15 +98,18 @@ export default function ReviewPage({ formState, onBack, onSubmitted }) {
           },
         ],
       };
-      
-      await executeYnabTransaction(transaction, "✅ YNAB split transaction sent!");
+
+      await executeYnabTransaction(
+        transaction,
+        "✅ YNAB split transaction sent!",
+      );
       return;
     }
 
     // Single-account transaction
-    const accountId = formState.account.bourso 
+    const accountId = formState.account.bourso
       ? getAccountIdByName(accounts, "Boursorama")
-      : formState.account.swile 
+      : formState.account.swile
         ? getAccountIdByName(accounts, "Swile")
         : getAccountIdByName(accounts, "Boursorama"); // Default fallback
 
@@ -111,7 +118,10 @@ export default function ReviewPage({ formState, onBack, onSubmitted }) {
       return;
     }
 
-    const transaction = createBaseTransaction(accountId, formState.amountMilliunits);
+    const transaction = createBaseTransaction(
+      accountId,
+      formState.amountMilliunits,
+    );
     await executeYnabTransaction(transaction, "✅ YNAB transaction sent!");
   }
 

--- a/src/ReviewPage.test.jsx
+++ b/src/ReviewPage.test.jsx
@@ -1,0 +1,144 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock modules first
+const mockCreateTransaction = vi.fn();
+
+vi.mock("./AppContext.jsx", () => ({
+  useAppContext: vi.fn(() => ({
+    ynabAPI: {
+      transactions: {
+        createTransaction: mockCreateTransaction,
+      },
+    },
+    budgetId: "test-budget-id",
+    accounts: [
+      { id: "swile-account-id", name: "Swile" },
+      { id: "bourso-account-id", name: "Boursorama" },
+    ],
+  })),
+}));
+
+vi.mock("./AuthProvider.jsx", () => ({
+  useAuth: vi.fn(() => ({
+    token: "test-token",
+    user: { uid: "test-user-id" },
+  })),
+}));
+
+vi.mock("./api/settleup", () => ({
+  addSettleUpTransaction: vi.fn(),
+  fetchSettleUpPermissions: vi.fn(),
+}));
+
+import { BOURSO_TRANSFER_PAYEE_ID } from "./constants.js";
+import ReviewPage from "./ReviewPage.jsx";
+
+// Mock props
+const defaultProps = {
+  formState: {
+    account: { swile: true, bourso: true },
+    amountMilliunits: -50000, // -50.00 €
+    swileMilliunits: -50000, // Swile covers full amount
+    payeeId: "test-payee-id",
+    payee: "Test Payee",
+    categoryId: "test-category-id",
+    description: "Test description",
+    target: { ynab: true },
+  },
+  onBack: vi.fn(),
+  onSubmitted: vi.fn(),
+};
+
+function renderWithRouter(component) {
+  return render(<BrowserRouter>{component}</BrowserRouter>);
+}
+
+describe("ReviewPage - Bourso split logic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates simple transaction when Swile covers full amount (no Bourso split)", async () => {
+    mockCreateTransaction.mockResolvedValue({
+      data: { transaction: { id: "test-transaction-id" } },
+    });
+
+    renderWithRouter(<ReviewPage {...defaultProps} />);
+
+    const submitButton = screen.getByRole("button", {
+      name: /confirm & submit/i,
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockCreateTransaction).toHaveBeenCalledWith("test-budget-id", {
+        transaction: {
+          account_id: "swile-account-id",
+          date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          amount: -50000,
+          payee_id: "test-payee-id",
+          payee_name: undefined,
+          category_id: "test-category-id",
+          memo: "Test description",
+          approved: true,
+        },
+      });
+    });
+
+    // Should not create a split transaction
+    const call = mockCreateTransaction.mock.calls[0];
+    expect(call[1].transaction.subtransactions).toBeUndefined();
+  });
+
+  it("creates split transaction when Swile does not cover full amount", async () => {
+    const propsWithPartialSwile = {
+      ...defaultProps,
+      formState: {
+        ...defaultProps.formState,
+        swileMilliunits: -30000, // Swile covers only -30.00 €, -20.00 € remaining
+      },
+    };
+
+    mockCreateTransaction.mockResolvedValue({
+      data: { transaction: { id: "test-transaction-id" } },
+    });
+
+    renderWithRouter(<ReviewPage {...propsWithPartialSwile} />);
+
+    const submitButton = screen.getByRole("button", {
+      name: /confirm & submit/i,
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockCreateTransaction).toHaveBeenCalledWith("test-budget-id", {
+        transaction: {
+          account_id: "swile-account-id",
+          date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          amount: -30000,
+          payee_id: "test-payee-id",
+          payee_name: undefined,
+          category_id: null,
+          memo: "Test description",
+          approved: true,
+          subtransactions: [
+            {
+              amount: -50000,
+              category_id: "test-category-id",
+              memo: "Test description",
+              payee_id: "test-payee-id",
+            },
+            {
+              amount: 20000, // transferInflowMilliunits = -30000 - (-50000) = 20000
+              payee_id: BOURSO_TRANSFER_PAYEE_ID,
+              transfer_account_id: "bourso-account-id",
+              memo: "Bourso completion",
+            },
+          ],
+        },
+      });
+    });
+  });
+});

--- a/src/components/AmountInput.test.jsx
+++ b/src/components/AmountInput.test.jsx
@@ -1,0 +1,170 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import AmountInput from "./AmountInput.jsx";
+
+describe("AmountInput with max/min constraints", () => {
+  it("caps input value at maximum when max prop is provided", () => {
+    const mockOnChange = vi.fn();
+    const maxValue = 0; // 0.00 € in milliunits
+
+    render(
+      <AmountInput
+        value={-10000} // Start with negative value (-10.00 €)
+        onChange={mockOnChange}
+        max={maxValue}
+      />,
+    );
+
+    const signButton = screen.getByRole("button");
+
+    // Click the sign toggle to change from negative to positive
+    fireEvent.click(signButton);
+
+    // This should toggle the value to +10000, but should be capped at max (0)
+    expect(mockOnChange).toHaveBeenCalledWith(maxValue);
+  });
+
+  it("caps value when value prop exceeds maximum", () => {
+    const mockOnChange = vi.fn();
+    const maxValue = 0; // 0.00 € in milliunits
+
+    const { rerender } = render(
+      <AmountInput
+        value={-10000} // Start with negative value (-10.00 €)
+        onChange={mockOnChange}
+        max={maxValue}
+      />,
+    );
+
+    // Change the value prop to a positive value that exceeds max
+    rerender(
+      <AmountInput
+        value={15000} // Change to positive value (+15.00 €)
+        onChange={mockOnChange}
+        max={maxValue}
+      />,
+    );
+
+    // The display should show the actual value (not capped) since this is controlled by the parent
+    // But if user tries to input, it should be capped
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "20.00" } });
+
+    // Should call onChange with the capped value (0 milliunits)
+    expect(mockOnChange).toHaveBeenCalledWith(maxValue);
+  });
+
+  it("caps pasted value at maximum when max prop is provided", () => {
+    const mockOnChange = vi.fn();
+    const maxValue = 0; // 0.00 € in milliunits
+
+    render(
+      <AmountInput
+        value={5000} // Start with positive value (5.00 €)
+        onChange={mockOnChange}
+        max={maxValue}
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+
+    // Try to paste 15.50 € (which should be capped at 0)
+    fireEvent.paste(input, {
+      clipboardData: {
+        getData: () => "15.50",
+      },
+    });
+
+    // Should call onChange with the capped value (0 milliunits)
+    expect(mockOnChange).toHaveBeenCalledWith(maxValue);
+  });
+
+  it("allows input below maximum when max prop is provided", () => {
+    const mockOnChange = vi.fn();
+    const maxValue = 0; // 0.00 € in milliunits
+
+    render(
+      <AmountInput
+        value={-10000} // Start with negative value (-10.00 €)
+        onChange={mockOnChange}
+        max={maxValue}
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+
+    // Input 5.00 € (which should result in -5000, below max of 0, so allowed)
+    fireEvent.change(input, { target: { value: "5.00" } });
+
+    // Should call onChange with the actual value (-5000 milliunits)
+    expect(mockOnChange).toHaveBeenCalledWith(-5000);
+  });
+
+  it("respects min constraint when min prop is provided", () => {
+    const mockOnChange = vi.fn();
+    const minValue = -50000; // -50.00 € in milliunits
+
+    render(
+      <AmountInput
+        value={-25000} // Start with -25.00 €
+        onChange={mockOnChange}
+        min={minValue}
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+
+    // Try to input 60.00 € (which should be capped at 50.00 € = -50000 milliunits minimum)
+    fireEvent.change(input, { target: { value: "60.00" } });
+
+    // Should call onChange with the minimum value (-50000 milliunits)
+    expect(mockOnChange).toHaveBeenCalledWith(minValue);
+  });
+
+  it("works correctly for Swile use case - enforces min constraint", () => {
+    const mockOnChange = vi.fn();
+    const transactionAmount = -50000; // -50.00 € transaction
+
+    render(
+      <AmountInput
+        value={-25000} // Start with -25.00 € Swile amount
+        onChange={mockOnChange}
+        min={transactionAmount} // Swile can't pay more than transaction amount
+        max={0} // Swile can't be positive
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+
+    // Try to input 60.00 € which would be -60000 milliunits (more negative than min)
+    // This should be capped to the minimum allowed value of -50000 milliunits
+    fireEvent.change(input, { target: { value: "60.00" } });
+
+    // Should call onChange with the minimum value (can't be more negative than transaction)
+    expect(mockOnChange).toHaveBeenCalledWith(transactionAmount);
+  });
+
+  it("works correctly for Swile use case - enforces max constraint", () => {
+    const mockOnChange = vi.fn();
+    const transactionAmount = -50000; // -50.00 € transaction
+
+    render(
+      <AmountInput
+        value={5000} // Start with positive value (+5.00 €)
+        onChange={mockOnChange}
+        min={transactionAmount} // Swile can't pay more than transaction amount
+        max={0} // Swile can't be positive
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+
+    // Try to input 10.00 € which would be +10000 milliunits (more than max of 0)
+    // This should be capped to the maximum allowed value of 0 milliunits
+    fireEvent.change(input, { target: { value: "10.00" } });
+
+    // Should call onChange with the maximum value (can't be positive)
+    expect(mockOnChange).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/components/SwileAmountSection.jsx
+++ b/src/components/SwileAmountSection.jsx
@@ -4,7 +4,7 @@ import { forwardRef } from "react";
 import AmountInput from "./AmountInput.jsx";
 
 const SwileAmountSection = forwardRef(function SwileAmountSection(
-  { swileMilliunits, setSwileMilliunits, max },
+  { swileMilliunits, setSwileMilliunits, min },
   ref,
 ) {
   return (
@@ -16,8 +16,8 @@ const SwileAmountSection = forwardRef(function SwileAmountSection(
         label="Amount paid by Swile"
         value={swileMilliunits}
         onChange={setSwileMilliunits}
-        min={0}
-        max={max}
+        min={min || undefined}
+        max={0}
       />
     </div>
   );
@@ -28,5 +28,5 @@ export default SwileAmountSection;
 SwileAmountSection.propTypes = {
   swileMilliunits: PropTypes.number.isRequired,
   setSwileMilliunits: PropTypes.func.isRequired,
-  max: PropTypes.number,
+  min: PropTypes.number,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,3 +13,6 @@ export const FIREBASE_TOKEN_REFRESH_INTERVAL = 50 * 60 * 1000; // 50 minutes
 
 // Timeout used in GroupedAutocomplete blur handler to allow dropdown click events to register before closing
 export const AUTOCOMPLETE_BLUR_TIMEOUT_MS = 120;
+
+// Bourso transfer payee ID (used for Bourso completion transactions)
+export const BOURSO_TRANSFER_PAYEE_ID = "eabe1e60-fa92-40f7-8636-5c8bcbf1404a";

--- a/src/version.js
+++ b/src/version.js
@@ -4,9 +4,9 @@
 export const VERSION_INFO = {
   "tag": "1.0.0",
   "branch": "38-swile-amount-needs-to-be-capped-at-the-transaction-amount",
-  "commit": "df27db5",
+  "commit": "48c0900",
   "isDirty": true,
-  "buildTime": "2025-07-23T11:48:56.711Z",
+  "buildTime": "2025-07-23T12:30:33.159Z",
   "version": "1.0.0",
   "shortVersion": "1.0.0"
 };

--- a/src/version.js
+++ b/src/version.js
@@ -3,10 +3,10 @@
 
 export const VERSION_INFO = {
   "tag": "1.0.0",
-  "branch": "SThor/issue35",
-  "commit": "da7c4a6",
+  "branch": "38-swile-amount-needs-to-be-capped-at-the-transaction-amount",
+  "commit": "df27db5",
   "isDirty": true,
-  "buildTime": "2025-07-23T10:51:28.071Z",
+  "buildTime": "2025-07-23T11:48:56.711Z",
   "version": "1.0.0",
   "shortVersion": "1.0.0"
 };


### PR DESCRIPTION
## Description

This PR implements two key improvements to the Swile payment handling system:

1. **Swile Amount Constraint Validation** (Issue #38)
2. **Smart Bourso Split Elimination** (Issue #39)

## Changes Made

### Swile Amount Capping (Issue #38)
- Added min/max constraint support to AmountInput component
- Swile amounts are now capped between 0€ (max) and transaction amount (min)
- Prevents users from entering invalid Swile payment amounts that exceed the total transaction value
- Renamed props for better semantic clarity (max → min in SwileAmountSection)

### Smart Bourso Split Logic (Issue #39)
- Eliminates unnecessary split transactions when Swile covers the full amount
- When swileMilliunits equals amountMilliunits, creates a simple transaction instead of split
- Maintains existing split logic for partial Swile coverage scenarios
- Refactored transaction creation logic for better maintainability and reduced code duplication

## Impact
- Improved user experience by preventing invalid input scenarios
- Cleaner YNAB transaction records (no more unnecessary 0€ Bourso transfers)
- More maintainable codebase with centralized constraint and transaction logic

Fixes #38, #39

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
